### PR TITLE
Update sonarwhal to webhint

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
-# sonarwhal
-docker image for sonarwhal. Uses `{ "extends": [ "web-recommended" ], "formatters": [ "json" ] }` by default but can be over written in `var/www`.
+# webhint
+docker image for webhint. Uses `{ "extends": [ "web-recommended" ], "formatters": [ "json" ] }` by default but can be over written in `var/www`.
 
 ## Supported tags and Dockerfile links
-- [`latest` (*Dockerfile*)](https://github.com/willfarrell/docker-sonarwhal/blob/master/jessie/Dockerfile)
-- [`alpine` (*Dockerfile*)](https://github.com/willfarrell/docker-sonarwhal/blob/master/alpine/Dockerfile)
+- [`latest` (*Dockerfile*)](https://github.com/willfarrell/docker-webhint/blob/master/jessie/Dockerfile)
+- [`alpine` (*Dockerfile*)](https://github.com/willfarrell/docker-webhint/blob/master/alpine/Dockerfile)
 
-- [`1.11.2` (*Dockerfile*)](https://github.com/willfarrell/docker-sonarwhal/blob/1.11.2/jessie/Dockerfile)
-- [`1.11.2-alpine` (*Dockerfile*)](https://github.com/willfarrell/docker-sonarwhal/blob/1.11.2/alpine/Dockerfile)
+- [`1.11.2` (*Dockerfile*)](https://github.com/willfarrell/docker-webhint/blob/1.11.2/jessie/Dockerfile)
+- [`1.11.2-alpine` (*Dockerfile*)](https://github.com/willfarrell/docker-webhint/blob/1.11.2/alpine/Dockerfile)
 
-[![](https://images.microbadger.com/badges/version/willfarrell/sonarwhal.svg)](http://microbadger.com/images/willfarrell/sonarwhal "Get your own version badge on microbadger.com") [![](https://images.microbadger.com/badges/image/willfarrell/sonarwhal.svg)](http://microbadger.com/images/willfarrell/sonarwhal "Get your own image badge on microbadger.com")
+[![](https://images.microbadger.com/badges/version/willfarrell/webhint.svg)](http://microbadger.com/images/willfarrell/webhint "Get your own version badge on microbadger.com") [![](https://images.microbadger.com/badges/image/willfarrell/webhint.svg)](http://microbadger.com/images/willfarrell/webhint "Get your own image badge on microbadger.com")
 
 
 ## Getting Started
@@ -18,24 +18,24 @@ You must have Docker installed. [Download](https://www.docker.com/community-edit
 
 ### Build
 ```bash
-docker build -t sonarwhal .
+docker build -t webhint .
 ```
 
 ### Testing
 ```bash
-docker runsonarwhal
+docker run webhint
 ```
 
 ### Pull
 ```bash
-docker pull willfarrell/sonarwhal
+docker pull willfarrell/webhint
 ```
 
 ## Deployment
 ```bash
-docker run willfarrell/sonarwhal https://example.com
+docker run willfarrell/webhint https://example.com
 ```
 
 ## Built With
-- [sonarwhal](https://sonarwhal.com)
+- [webhint](https://webhint.io)
 - [Docker](https://www.docker.com)

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:10-alpine
 
-ENV VERSION=1.11.2
+ENV VERSION=3.2.0
 
 # Start glibc - https://hub.docker.com/r/frolvlad/alpine-glibc/~/dockerfile/
 # Required due too `canvas-prebuilt` is based off glibc
@@ -42,13 +42,13 @@ RUN ALPINE_GLIBC_BASE_URL="https://github.com/sgerrand/alpine-pkg-glibc/releases
 
 WORKDIR /var/www
 
-# Work around: https://github.com/sonarwhal/sonarwhal/issues/600#issuecomment-339981842
+# Work around: https://github.com/webhintio/hint/issues/600#issuecomment-339981842
 RUN apk update && \
     apk upgrade && \
-    npm i -g --engine-strict sonarwhal@${VERSION} --unsafe-perm=true && \
-    npm i -g @sonarwhal/configuration-web-recommended @sonarwhal/formatter-json && \
-    echo '{ "extends": [ "web-recommended" ], "formatters": [ "json" ] }' > .sonarwhalrc
+    npm i -g --engine-strict hint@${VERSION} --unsafe-perm=true && \
+    npm i -g @hint/configuration-web-recommended @hint/formatter-json && \
+    echo '{ "extends": [ "web-recommended" ], "formatters": [ "json" ] }' > .hintrc
 
-ENTRYPOINT ["sonarwhal"]
+ENTRYPOINT ["hint"]
 CMD ["-h"]
 

--- a/jessie/Dockerfile
+++ b/jessie/Dockerfile
@@ -4,12 +4,12 @@ ENV VERSION=1.11.2
 
 WORKDIR /var/www
 
-# Work around: https://github.com/sonarwhal/sonarwhal/issues/600#issuecomment-339981842
+# Work around: https://github.com/webhintio/hint/issues/600#issuecomment-339981842
 RUN apt-get update && \
     apt-get install -y curl apt-transport-https && \
-    npm i -g --engine-strict sonarwhal@${VERSION} --unsafe-perm=true && \
-    npm i -g @sonarwhal/configuration-web-recommended @sonarwhal/formatter-json && \
-    echo '{ "extends": [ "web-recommended" ], "formatters": [ "json" ] }' > .sonarwhalrc
+    npm i -g --engine-strict hint@${VERSION} --unsafe-perm=true && \
+    npm i -g @hint/configuration-web-recommended @hint/formatter-json && \
+    echo '{ "extends": [ "web-recommended" ], "formatters": [ "json" ] }' > .hintrc
 
-ENTRYPOINT ["sonarwhal"]
+ENTRYPOINT ["hint"]
 CMD ["-h"]

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "sonarwhal",
-  "version": "1.11.2",
+  "name": "webhint",
+  "version": "3.2.0",
   "dependencies": {
-    "sonarwhal": "1.11.2"
+    "hint": "3.2.0"
   }
 }


### PR DESCRIPTION
sonarwhal was renamed to webhint. This PR updates any references
to the new package.

Ref: https://medium.com/webhint/webhint-a-hinting-engine-for-the-web-ef0d3fa32ea9

**Note:** I've updated also the references to the repo, etc. and remove any reference to sonarwhal. There might be some work on your side (rename repo, publish new image, etc.).

Thanks!